### PR TITLE
feat: allow longer lines in commit descriptions

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,2 +1,5 @@
 extends:
   - "@commitlint/config-conventional"
+rules: {
+  'body-max-line-length': [2, 'always', 500],
+},


### PR DESCRIPTION
We are experiencing again limitations on line length in commit descriptions: https://github.com/turo/node-urls/actions/runs/4494104629/jobs/7906167091?pr=343#step:2:993

To avoid adding the specific config to each repo, as it was before (e.g. https://github.com/turo/node-urls/commit/1ae20e36f34c4a0703688d028978dcddb196450a), we can add the rule to this top-level repo that is extended in each package.