### PR TITLE
ci: bumps semantic release version to use node16

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: rhysd/actionlint
       - name: Semantic release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         with:
           extra_plugins: |
             semantic-release-github-pullrequest


### PR DESCRIPTION

**Description**

v2 fails during release. v3 uses a node16 environment so it should not complain about ESM



**Changes**

* ci: bumps semantic release version to use node16

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
